### PR TITLE
feat(HACBS-472): fetch mapping file

### DIFF
--- a/definitions/component-mapping/component-mapping.yaml
+++ b/definitions/component-mapping/component-mapping.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: m5-release-pipeline
+spec:
+  params:
+    - name: mapping-file
+      type: string
+      description: The mapping to apply to the snapshot
+  tasks:
+    - name: get-mapping-file
+      taskRef:
+        name: get-mapping-file
+        bundle: quay.io/hacbs-release/component-mapping:main
+      params:
+        - name: mapping-file
+          value: "$(params.mapping-file)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: get-mapping-file
+spec:
+  params:
+    - name: mapping-file
+      type: string
+      description: The file that defines the mapping to apply to the snapshot
+  results:
+    - name: mapping
+      description: The retrieved mapping file as a string
+  steps:
+    - name: get-mapping-file
+      image: quay.io/hacbs-release/release-utils
+      script: |
+        #!/usr/bin/env bash
+        mapping=$(curl $(params.mapping-file) | yq -o=json -I=0)
+        echo ${mapping} | tee $(results.mapping.path)


### PR DESCRIPTION
This commit adds a milestone 5 definition containing a pipeline with just
one task. The task will retrieve the mapping file passed in as a parameter,
convert it into a json, and save it as a task result to be used by later
tasks.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>